### PR TITLE
Update README.md - for megadocker_v4 creation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,22 @@ Megadocker update
 1. The vuiiscci_mega_docker_4.0.2-2020-03-19.img is not built from scratch. It is copied from vuiiscci_mega_docker_2.0.0-2018-11-28.img since old ldax uses mega_docker_2 to run all spiders.
 2. We do not use vuiiscci_mega_docker_3.0.0-2018-11-28.img as a starting point is that, mega_docker_3 upgrade gclib. We can see the difference at /lib64. The upgrade will make FreeSurfer binary executable have segmentaion fault. The upgade in megadocker_3 was for obsolete surf_* spiders. Due to those surf_* have used Dax-1.0 yaml build, there is no way to keep maintaining megadocker_3.
 3. There is no system library or new software installed in mega_docker_v4.0.2, update are all about python spider script and some text-base files. Here are a summary of update:
+
 (1) /data/mcr/masimatlab/trunk/xnatspiders/spiders/Spider_fMRI_Preprocess.py
 Just adding one line of code to make sure string array does not contain unicode. Shunxing modified on original spiders is due to such a minor change (it is probably not the best practice), and I don't want to generate a newer version of fMRI_Preprocess (i.e., Spider_fMRI_Preprocess_v1_0_0.py) to re-run whole the modified spiders on whole projects' sessions. 
+
 (2) /data/mcr/masimatlab/trunk/xnatspiders/spiders/Spider_Cerebellum_Segmentation_v1_0_1.py
 The updated cerebellum segmentation spiders. We find Spider_Cerebellum_Segmentation_v1_0_0.py original spider was modified in megadocker_v2 by Justin, which was inconsistent on SVN. For the reason of version control, Shunxing created a new Spider.
+
 (3) /data/mcr/masimatlab/trunk/xnatspiders/spiders/Spider_Seeleyfmripreproc_v3_0_2.py
 Fixed the Spider_Seeleyfmripreproc_v3_0_1.py issues on running sessions without T2 imaging.
+
 (4) /data/mcr/masimatlab/trunk/xnatspiders/spiders/BLSA_hack/Spider_VBMQA.py
 Maybe it is not the best practice again, but the Spider_VBMQA.py in spiders folder shares the same name in spiders/BLSA_hack folder. The reason for this is for version control, namely avoid running VBMQA higher verson on all sessions. The spiders/BLSA_hack/Spider_VBMQA.py was previously stored on masispider account's home directory. The content of that file is not the same with the one at SVN. So we made such a 'hacking' way.
+
 (5) /data/mcr/ldax_setup/bashrc_ldax
 A fresh bashrc which is supposed to be stored as /home/$USER/.bashrc
+
 (6) /data/mcr/ldax_setup/matlab/start.m
 A local backup for FreeSurfer set up.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,39 @@ This project aims to optimize dax build performance.
 
 Build and setup a new virtual environment for dax. Implement cache mechanism during dax build (only on in dax build). Optimized code to remove unnecessary slow & duplicate url query. 
 
-Rename dax_new to LDax for Legacy Distributed Automation for Xnat version - 03/03/2020
+Rename project dax_new to LDax for Legacy Distributed Automation for Xnat version - 03/03/2020
+
+Megadocker update
+------------
+1. The vuiiscci_mega_docker_4.0.2-2020-03-19.img is not built from scratch. It is copied from vuiiscci_mega_docker_2.0.0-2018-11-28.img since old ldax uses mega_docker_2 to run all spiders.
+2. We do not use vuiiscci_mega_docker_3.0.0-2018-11-28.img as a starting point is that, mega_docker_3 upgrade gclib. We can see the difference at /lib64. The upgrade will make FreeSurfer binary executable have segmentaion fault. The upgade in megadocker_3 was for obsolete surf_* spiders. Due to those surf_* have used Dax-1.0 yaml build, there is no way to keep maintaining megadocker_3.
+3. There is no system library or new software installed in mega_docker_v4.0.2, update are all about python spider script and some text-base files. Here are a summary of update:
+(1) /data/mcr/masimatlab/trunk/xnatspiders/spiders/Spider_fMRI_Preprocess.py
+Just adding one line of code to make sure string array does not contain unicode. Shunxing modified on original spiders is due to such a minor change (it is probably not the best practice), and I don't want to generate a newer version of fMRI_Preprocess (i.e., Spider_fMRI_Preprocess_v1_0_0.py) to re-run whole the modified spiders on whole projects' sessions. 
+(2) /data/mcr/masimatlab/trunk/xnatspiders/spiders/Spider_Cerebellum_Segmentation_v1_0_1.py
+The updated cerebellum segmentation spiders. We find Spider_Cerebellum_Segmentation_v1_0_0.py original spider was modified in megadocker_v2 by Justin, which was inconsistent on SVN. For the reason of version control, Shunxing created a new Spider.
+(3) /data/mcr/masimatlab/trunk/xnatspiders/spiders/Spider_Seeleyfmripreproc_v3_0_2.py
+Fixed the Spider_Seeleyfmripreproc_v3_0_1.py issues on running sessions without T2 imaging.
+(4) /data/mcr/masimatlab/trunk/xnatspiders/spiders/BLSA_hack/Spider_VBMQA.py
+Maybe it is not the best practice again, but the Spider_VBMQA.py in spiders folder shares the same name in spiders/BLSA_hack folder. The reason for this is for version control, namely avoid running VBMQA higher verson on all sessions. The spiders/BLSA_hack/Spider_VBMQA.py was previously stored on masispider account's home directory. The content of that file is not the same with the one at SVN. So we made such a 'hacking' way.
+(5) /data/mcr/ldax_setup/bashrc_ldax
+A fresh bashrc which is supposed to be stored as /home/$USER/.bashrc
+(6) /data/mcr/ldax_setup/matlab/start.m
+A local backup for FreeSurfer set up.
+
+job_template update
+------------
+(1) The ldax job template is stored at /home/vuiisccidev/.dax_template/job_template.txt
+(2) Add session count to avoid too many Xnat download running at the same time. The current session max limit is 50.
+(3) We stop using whole ACCRE's home, and just binding necessary setting files as follows. The bashrc has already stored in megadocekr (bashrc_ldax)
+--bind /home/$USER/.dax_settings.ini:/home/$USER/.dax_settings.ini --bind /home/$USER/.daxnetrc:/home/$USER/.daxnetrc --bind /scratch/$USER:/scratch/$USER --bind /tmp:/tmp 
+(4) The startup script of mega_docker_v4 is a bit change to setup bash and FreeSurfer environment
+cp /data/mcr/ldax_setup/bashrc_ldax /home/vuiisccidev/.bashrc && \
+source /home/vuiisccidev/.bashrc
+cp -r /data/mcr/ldax_setup/matlab /home/vuiisccidev/ && \
+
+ldax setup update (TODO)
+------------
 
 Summary:
 ------------

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -448,7 +448,8 @@ cluster queue"
         #                cachedir = f.readlines()
                         #print('#########%s' % cachedir);
         #    cachedir = '/home/vuiisccidev/.xnatcache/' # force to set cache here - need to remove in future - SHUNXING - 11/27/2019
-            cachedir = '/home/vuiisccidev/.xnatcache_%s/' % str(uuid.uuid1()) # for random cachedir        
+            tmp_home = os.path.expanduser('~')
+            cachedir = '%s/.xnatcache_%s/' % (tmp_home,str(uuid.uuid1())) # for random cachedir        
         #SHUNXING hack XnatUtils get_interface
         # change it to get_interface_build_with_cache , pass cachedir argument
         with XnatUtils.get_interface_build_with_cache(self.xnat_host, self.xnat_user,

--- a/dax/launcher.py
+++ b/dax/launcher.py
@@ -459,9 +459,10 @@ cluster queue"
                 LOGGER.debug('SHUNXING cache is saved at:%s'% str(cachedir))
                 LOGGER.debug('cacheflag = %d' % xnat._get_cacheFlag())
                 # cache is on when cacheFlag number is larger than 0
-                # here we just set it as 1
+                # here we just set it as -1
                 LOGGER.info('SHUNXING new cache feature')
-                tmpCacheFlag = 1 ##########################################################################################################################
+                LOGGER.info('SHUNXING temporarily turn off cache feature for debugging xnat2 timeout issue')
+                tmpCacheFlag = -1 ##########################################################################################################################
                 xnat._set_cacheFlag(tmpCacheFlag)
                 LOGGER.debug('cacheflag = %d' % xnat._get_cacheFlag())
 


### PR DESCRIPTION
Update readme.md

temporarily turn off the ldax_v2 cache feature. 